### PR TITLE
Added GSoC label in sidebar

### DIFF
--- a/_templates/sidebar_contact.html
+++ b/_templates/sidebar_contact.html
@@ -13,6 +13,15 @@
             Developer guide</a></li>
 
   </ul>
+<h3>{{ _('GSoC') }}</h3>
+    <ul class="simple">
+        <li>
+            <a class="reference external" href="https://github.com/networkx/networkx/wiki/GSoC-2015">
+                GSoC 2015</a></li>
+        <li>
+            <a class="reference external" href="https://github.com/networkx/networkx/wiki/GSoC-2015-project-ideas">
+                GSoC 2015 Ideas Page</a></li>
+    </ul>
 <a href="https://github.com/networkx/networkx"> 
 <img src='_static/octocats.png' alt='octocat' width=96>
 </a>


### PR DESCRIPTION
As suggested by @Midnighter in https://groups.google.com/forum/#!topic/networkx-discuss/t1Ifu8m1Cz4 I added a GSoC label on the website which provides link for the introduction page for GSoC and the ideas page for GSoC. Google will soon announce the selected orgs so we can expect traffic on networkx's website, this could help prospective students.
