### PR TITLE
r/networkx.github.com/networkx.github.io/

### DIFF
--- a/_scripts/gh-pages.py
+++ b/_scripts/gh-pages.py
@@ -29,7 +29,7 @@ from subprocess import Popen, PIPE, CalledProcessError, check_call
 
 pages_dir = 'gh-pages'
 html_dir = '_build/html'
-pages_repo = 'git@github.com:networkx/networkx.github.com.git'
+pages_repo = 'git@github.com:networkx/networkx.github.io.git'
 
 #-----------------------------------------------------------------------------
 # Functions

--- a/_templates/index.html
+++ b/_templates/index.html
@@ -32,7 +32,7 @@
        <span class="linkdescr">using the library</span></p>
   </td>
   <td width="33%">
-    <p class="biglink"><a class="biglink" href="http://networkx.github.com/documentation/latest/reference/index.html">Reference</a><br/>
+    <p class="biglink"><a class="biglink" href="http://networkx.github.io/documentation/latest/reference/index.html">Reference</a><br/>
        <span class="linkdescr">all functions and methods</span></p>
   </td></tr>
 </table>

--- a/_templates/sidebar_contact.html
+++ b/_templates/sidebar_contact.html
@@ -9,7 +9,7 @@
     <li><a class="reference external" href="https://github.com/networkx/networkx/issues">
             Issue tracker</a></li>
 
-    <li><a class="reference external" href="http://networkx.github.com/documentation/development/developer">
+    <li><a class="reference external" href="http://networkx.github.io/documentation/development/developer">
             Developer guide</a></li>
 
   </ul>

--- a/_templates/sidebar_versions.html
+++ b/_templates/sidebar_versions.html
@@ -5,14 +5,14 @@
         <div class="tile">
                 <h4>Latest Release</h4>
         1.9.1 &ndash; 20 September 2014<br/>
-        <a href="http://pypi.python.org/pypi/networkx/">downloads</a> | <a href="http://networkx.github.com/documentation/networkx-1.9.1/">docs</a> | <a href="http://networkx.github.com/documentation/networkx-1.9.1/_downloads/networkx_reference.pdf">pdf</a>
+        <a href="http://pypi.python.org/pypi/networkx/">downloads</a> | <a href="http://networkx.github.io/documentation/networkx-1.9.1/">docs</a> | <a href="http://networkx.github.io/documentation/networkx-1.9.1/_downloads/networkx_reference.pdf">pdf</a>
         </div>
 
         <div class="tile">
                 <h4>Development</h4>
         2.0dev<br/>
         <a href="https://github.com/networkx/networkx">github</a> | <a 
-href="http://networkx.github.com/documentation/development/">docs</a> | <a href="http://networkx.github.com/documentation/development/_downloads/networkx_reference.pdf">pdf</a>
+href="http://networkx.github.io/documentation/development/">docs</a> | <a href="http://networkx.github.io/documentation/development/_downloads/networkx_reference.pdf">pdf</a>
         </br>
         <a href="https://travis-ci.org/networkx/networkx"> 
           <img src="https://travis-ci.org/networkx/networkx.png" alt='travis' width=77>

--- a/documentation.rst
+++ b/documentation.rst
@@ -3,23 +3,23 @@ Documentation
 =============
 
 If you are new to NetworkX take a look at the
-`tutorial <http://networkx.github.com/documentation/latest/tutorial/>`_.
+`tutorial <http://networkx.github.io/documentation/latest/tutorial/>`_.
 
-The `examples <http://networkx.github.com/documentation/networkx-1.9.1/examples/>`_
+The `examples <http://networkx.github.io/documentation/networkx-1.9.1/examples/>`_
 show some simple and complicated ways to use NetworkX.
 
 Full Documentation Versions
 ---------------------------
 
-* `Latest <http://networkx.github.com/documentation/networkx-1.9.1/>`_
-* `Development <http://networkx.github.com/documentation/development/>`_
+* `Latest <http://networkx.github.io/documentation/networkx-1.9.1/>`_
+* `Development <http://networkx.github.io/documentation/development/>`_
 
 Archived Documentation
 ----------------------
 
-* `NetworkX-1.9.1 <http://networkx.github.com/documentation/networkx-1.9.1/>`_
-* `NetworkX-1.9 <http://networkx.github.com/documentation/networkx-1.9/>`_
-* `NetworkX-1.8.1 <http://networkx.github.com/documentation/networkx-1.8.1/>`_
-* `NetworkX-1.8 <http://networkx.github.com/documentation/networkx-1.8/>`_
-* `NetworkX-1.7 <http://networkx.github.com/documentation/networkx-1.7/>`_
+* `NetworkX-1.9.1 <http://networkx.github.io/documentation/networkx-1.9.1/>`_
+* `NetworkX-1.9 <http://networkx.github.io/documentation/networkx-1.9/>`_
+* `NetworkX-1.8.1 <http://networkx.github.io/documentation/networkx-1.8.1/>`_
+* `NetworkX-1.8 <http://networkx.github.io/documentation/networkx-1.8/>`_
+* `NetworkX-1.7 <http://networkx.github.io/documentation/networkx-1.7/>`_
 * `Older versions <http://networkx.lanl.gov/archive/>`_

--- a/examples.rst
+++ b/examples.rst
@@ -10,6 +10,6 @@ Quick Example
 >>> print(G.edges())
 [(1, 2)]
 
-See more `simple and complicated examples <http://networkx.github.com/documentation/latest/examples/>`_, or
-a `gallery <http://networkx.github.com/documentation/latest/gallery.html>`_.
+See more `simple and complicated examples <http://networkx.github.io/documentation/latest/examples/>`_, or
+a `gallery <http://networkx.github.io/documentation/latest/gallery.html>`_.
 of network drawings.


### PR DESCRIPTION
This standardizes all documentation to reflect the [Github's change to the `github.io` domain for pages](https://github.com/blog/1452-new-github-pages-domain-github-io).

Sister PR in networkx/networkx#1443
